### PR TITLE
[Ready] Depth Sorting Feature (Alternative to #1)

### DIFF
--- a/projects/VS2017.WINDOWS/Ngine/Ngine.vcxproj
+++ b/projects/VS2017.WINDOWS/Ngine/Ngine.vcxproj
@@ -49,7 +49,6 @@
     <ClInclude Include="..\..\..\src\Graphics\GraphicsManager.h" />
     <ClInclude Include="..\..\..\src\Graphics\RenderTarget.h" />
     <ClInclude Include="..\..\..\src\Graphics\Sprite.h" />
-    <ClInclude Include="..\..\..\src\Graphics\SpriteBatch.h" />
     <ClInclude Include="..\..\..\src\Graphics\Texture2D.h" />
     <ClInclude Include="..\..\..\src\Input\Gamepad.h" />
     <ClInclude Include="..\..\..\src\Input\Keyboard.h" />
@@ -83,7 +82,6 @@
     <ClCompile Include="..\..\..\src\Graphics\GraphicsManager.cpp" />
     <ClCompile Include="..\..\..\src\Graphics\RenderTarget.cpp" />
     <ClCompile Include="..\..\..\src\Graphics\Sprite.cpp" />
-    <ClCompile Include="..\..\..\src\Graphics\SpriteBatch.cpp" />
     <ClCompile Include="..\..\..\src\Graphics\Texture2D.cpp" />
     <ClCompile Include="..\..\..\src\Input\Gamepad.cpp" />
     <ClCompile Include="..\..\..\src\Input\Keyboard.cpp" />

--- a/projects/VS2017.WINDOWS/Ngine/Ngine.vcxproj.filters
+++ b/projects/VS2017.WINDOWS/Ngine/Ngine.vcxproj.filters
@@ -111,9 +111,6 @@
     <ClInclude Include="..\..\..\src\Audio\Music.h">
       <Filter>Audio</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\src\Graphics\SpriteBatch.h">
-      <Filter>Graphics</Filter>
-    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Core">
@@ -223,9 +220,6 @@
     </ClCompile>
     <ClCompile Include="..\..\..\src\Audio\Music.cpp">
       <Filter>Audio</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\src\Graphics\SpriteBatch.cpp">
-      <Filter>Graphics</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/src/Core/BaseEntity.cpp
+++ b/src/Core/BaseEntity.cpp
@@ -28,8 +28,8 @@ namespace NerdThings::Ngine::Core {
 
     // Public Constructor(s)
 
-    BaseEntity::BaseEntity(Scene *parentScene_, const Math::TVector2 position_, int depth_)
-        : _Depth(depth_), _ParentScene(parentScene_), _Position(position_) {
+    BaseEntity::BaseEntity(Scene *parentScene_, const Math::TVector2 position_, int depth_, bool canCull_)
+        : _CanCull(canCull_), _Depth(depth_), _ParentScene(parentScene_), _Position(position_) {
         if (parentScene_ == nullptr)
             throw std::runtime_error("Cannot give an entity a null parent scene.");
 
@@ -51,6 +51,10 @@ namespace NerdThings::Ngine::Core {
 
     // Public Methods
 
+    bool BaseEntity::CheckForCulling(Math::TRectangle cullArea_) {
+        return cullArea_.Contains(GetPosition());
+    }
+
     void BaseEntity::Draw() {
         // Trigger draw
         OnDraw({});
@@ -59,6 +63,10 @@ namespace NerdThings::Ngine::Core {
     void BaseEntity::DrawCamera() {
         // Trigger drawcamera
         OnDrawCamera({});
+    }
+
+    bool BaseEntity::GetCanCull() {
+        return _CanCull;
     }
 
     std::vector<Component *> BaseEntity::GetComponents() {

--- a/src/Core/BaseEntity.cpp
+++ b/src/Core/BaseEntity.cpp
@@ -28,10 +28,13 @@ namespace NerdThings::Ngine::Core {
 
     // Public Constructor(s)
 
-    BaseEntity::BaseEntity(Scene *parentScene_, const Math::TVector2 position_)
-        : _ParentScene(parentScene_), _Position(position_) {
+    BaseEntity::BaseEntity(Scene *parentScene_, const Math::TVector2 position_, int depth_)
+        : _Depth(depth_), _ParentScene(parentScene_), _Position(position_) {
         if (parentScene_ == nullptr)
             throw std::runtime_error("Cannot give an entity a null parent scene.");
+
+        // Set initial depth
+        _ParentScene->InternalSetEntityDepth(_Depth, this);
     }
 
     // Destructor
@@ -43,19 +46,17 @@ namespace NerdThings::Ngine::Core {
         }
 
         // Unbind all events
-        UnsubscribeFromCameraDraw();
-        UnsubscribeFromDraw();
         UnsubscribeFromUpdate();
     }
 
     // Public Methods
 
-    void BaseEntity::Draw(EventArgs &e) {
+    void BaseEntity::Draw() {
         // Trigger draw
         OnDraw({});
     }
 
-    void BaseEntity::DrawCamera(EventArgs &e) {
+    void BaseEntity::DrawCamera() {
         // Trigger drawcamera
         OnDrawCamera({});
     }
@@ -68,6 +69,10 @@ namespace NerdThings::Ngine::Core {
         }
 
         return vec;
+    }
+
+    int BaseEntity::GetDepth() const {
+        return _Depth;
     }
 
     Math::TVector2 BaseEntity::GetOrigin() const {
@@ -117,6 +122,11 @@ namespace NerdThings::Ngine::Core {
         return false;
     }
 
+    void BaseEntity::SetDepth(int depth_) {
+        _ParentScene->InternalUpdateEntityDepth(_Depth, depth_, this);
+        _Depth = depth_;
+    }
+
     void BaseEntity::SetOrigin(Math::TVector2 origin_) {
         _Origin = origin_;
         OnTransformChanged({_Origin, _Position, _Rotation, 1});
@@ -137,32 +147,6 @@ namespace NerdThings::Ngine::Core {
     //     OnTransformChanged({ _Origin, _Position, _Rotation, _Scale });
     // }
 
-    bool BaseEntity::SubscribeToCameraDraw() {
-        if (_ParentScene != nullptr) {
-            if (_OnDrawCameraRef.ID < 0) {
-                _OnDrawCameraRef = _ParentScene->OnDrawCamera.Bind<BaseEntity>(this, &BaseEntity::DrawCamera);
-                return true;
-            } else {
-                // We still have an event, soooo...
-                return true;
-            }
-        }
-        return false;
-    }
-
-    bool BaseEntity::SubscribeToDraw() {
-        if (_ParentScene != nullptr) {
-            if (_OnDrawRef.ID < 0) {
-                _OnDrawRef = _ParentScene->OnDraw.Bind<BaseEntity>(this, &BaseEntity::Draw);
-                return true;
-            } else {
-                // We still have an event, soooo...
-                return true;
-            }
-        }
-        return false;
-    }
-
     bool BaseEntity::SubscribeToUpdate() {
         if (_ParentScene != nullptr) {
             if (_OnUpdateRef.ID < 0) {
@@ -174,14 +158,6 @@ namespace NerdThings::Ngine::Core {
             }
         }
         return false;
-    }
-
-    void BaseEntity::UnsubscribeFromCameraDraw() {
-        _OnDrawCameraRef.UnBind();
-    }
-
-    void BaseEntity::UnsubscribeFromDraw() {
-        _OnDrawRef.UnBind();
     }
 
     void BaseEntity::UnsubscribeFromUpdate() {

--- a/src/Core/BaseEntity.h
+++ b/src/Core/BaseEntity.h
@@ -34,6 +34,11 @@ namespace NerdThings::Ngine::Core {
         // Private fields
 
         /*
+         * Whether or not this entity can be culled
+         */
+        bool _CanCull = false;
+
+        /*
          * The list of all components.
          * All components are given a name for easy identification.
          */
@@ -113,7 +118,7 @@ namespace NerdThings::Ngine::Core {
         /*
          * Create a BaseEntity.
          */
-        BaseEntity(Scene *parentScene_, Math::TVector2 position_, int depth_ = 0);
+        BaseEntity(Scene *parentScene_, Math::TVector2 position_, int depth_ = 0, bool canCull_ = false);
 
         // Destructor
 
@@ -144,6 +149,12 @@ namespace NerdThings::Ngine::Core {
         }
 
         /*
+         * This is used to determine if this entity should be culled.
+         * This can allow you to hide this if the collision box is not contained instead.
+         */
+        virtual bool CheckForCulling(Math::TRectangle cullArea_);
+
+        /*
          * Draw code for the entity
          */
         virtual void Draw();
@@ -165,6 +176,11 @@ namespace NerdThings::Ngine::Core {
 
             return nullptr;
         }
+
+        /*
+         * Check if this entity can be culled
+         */
+        bool GetCanCull();
 
         /*
          * Get all components

--- a/src/Core/BaseEntity.h
+++ b/src/Core/BaseEntity.h
@@ -40,14 +40,9 @@ namespace NerdThings::Ngine::Core {
         std::map<std::string, Component*> _Components;
 
         /*
-         * On draw event reference
+         * Depth layer
          */
-        EventHandleRef<EventArgs> _OnDrawRef;
-
-        /*
-         * On draw camera event reference
-         */
-        EventHandleRef<EventArgs> _OnDrawCameraRef;
+        int _Depth;
 
         /*
          * On update event reference
@@ -118,7 +113,7 @@ namespace NerdThings::Ngine::Core {
         /*
          * Create a BaseEntity.
          */
-        BaseEntity(Scene *parentScene_, Math::TVector2 position_);
+        BaseEntity(Scene *parentScene_, Math::TVector2 position_, int depth_ = 0);
 
         // Destructor
 
@@ -151,12 +146,12 @@ namespace NerdThings::Ngine::Core {
         /*
          * Draw code for the entity
          */
-        virtual void Draw(EventArgs &e);
+        virtual void Draw();
 
         /*
          * Draw code for the entity with camera translation
          */
-        virtual void DrawCamera(EventArgs &e);
+        virtual void DrawCamera();
 
         /*
          * Get a component by name.
@@ -175,6 +170,11 @@ namespace NerdThings::Ngine::Core {
          * Get all components
          */
         std::vector<Component*> GetComponents();
+
+        /*
+         * Get the entity depth
+         */
+        int GetDepth() const;
 
         /*
          * Get entity origin
@@ -232,6 +232,11 @@ namespace NerdThings::Ngine::Core {
         bool RemoveComponent(const std::string &name_);
 
         /*
+         * Set the entity depth
+         */
+        void SetDepth(int depth_);
+
+        /*
          * Set entity origin
          */
         void SetOrigin(Math::TVector2 origin_);
@@ -252,29 +257,9 @@ namespace NerdThings::Ngine::Core {
         // void SetScale(float scale_);
 
         /*
-         * Subscribe to draw events in the scene with camera translation
-         */
-        bool SubscribeToCameraDraw();
-
-        /*
-         * Subscribe to draw events in the scene
-         */
-        bool SubscribeToDraw();
-
-        /*
          * Subscribe to update events in the scene
          */
         bool SubscribeToUpdate();
-
-        /*
-         * Unsubscribe from update events in the scene with camera translation
-         */
-        void UnsubscribeFromCameraDraw();
-
-        /*
-         * Unsubscribe from update events in the scene
-         */
-        void UnsubscribeFromDraw();
 
         /*
          * Unsubscribe from update events in the scene

--- a/src/Core/Component.cpp
+++ b/src/Core/Component.cpp
@@ -26,21 +26,13 @@ namespace NerdThings::Ngine::Core {
 
     void Component::SubscribeToCameraDraw() {
         if (HasParent()) {
-            // Check the entity subscribed to draw
-            // If not, subscribe
-            if (_ParentEntity->SubscribeToCameraDraw()) {
-                _OnDrawCameraRef = _ParentEntity->OnDrawCamera.Bind(this, &Component::DrawCamera);
-            }
+            _OnDrawCameraRef = _ParentEntity->OnDrawCamera.Bind(this, &Component::DrawCamera);
         }
     }
 
     void Component::SubscribeToDraw() {
         if (HasParent()) {
-            // Check the entity subscribed to draw
-            // If not, subscribe
-            if (_ParentEntity->SubscribeToDraw()) {
-                _OnDrawRef = _ParentEntity->OnDraw.Bind(this, &Component::Draw);
-            }
+            _OnDrawRef = _ParentEntity->OnDraw.Bind(this, &Component::Draw);
         }
     }
 
@@ -53,9 +45,6 @@ namespace NerdThings::Ngine::Core {
             }
         }
     }
-
-    // TODO: Devise a way to allow the parent entity to unsubscribe from these events
-    // TODO: If they are no longer needed
 
     void Component::UnsubscribeFromCameraDraw() {
         _OnDrawCameraRef.UnBind();

--- a/src/Core/Game.cpp
+++ b/src/Core/Game.cpp
@@ -76,6 +76,10 @@ namespace NerdThings::Ngine::Core {
         return _UpdateFPS;
     }
 
+    Math::TVector2 Game::GetDimensions() const {
+        return { (float)_IntendedWidth, (float)_IntendedHeight };
+    }
+
     int Game::GetDrawFPS() const {
         return _DrawFPS;
     }

--- a/src/Core/Game.h
+++ b/src/Core/Game.h
@@ -127,6 +127,11 @@ namespace NerdThings::Ngine::Core {
         [[nodiscard]] int GetFPS() const;
 
         /*
+         * Get game dimensions
+         */
+        Math::TVector2 GetDimensions() const;
+
+        /*
          * Get the target draw FPS.
          */
         [[nodiscard]] int GetDrawFPS() const;

--- a/src/Core/Scene.cpp
+++ b/src/Core/Scene.cpp
@@ -14,6 +14,8 @@
 
 #include "Scene.h"
 
+#include "BaseEntity.h"
+
 namespace NerdThings::Ngine::Core {
     // Private Methods
 
@@ -33,11 +35,27 @@ namespace NerdThings::Ngine::Core {
         // Invoke draw calls
         OnDraw({});
 
+        // Draw entities
+        for (auto pair : _EntityDepths) {
+            auto vec = pair.second;
+            for (auto ent : vec) {
+                ent->Draw();
+            }
+        }
+
         // Draw with camera
         if (_ActiveCamera != nullptr)
             _ActiveCamera->BeginCamera();
 
         OnDrawCamera({});
+
+        // Draw entities with camera
+        for (auto pair : _EntityDepths) {
+            auto vec = pair.second;
+            for (auto ent : vec) {
+                ent->DrawCamera();
+            }
+        }
 
         if (_ActiveCamera != nullptr)
             _ActiveCamera->EndCamera();
@@ -45,6 +63,20 @@ namespace NerdThings::Ngine::Core {
 
     Graphics::TCamera *Scene::GetActiveCamera() const {
         return _ActiveCamera;
+    }
+
+    void Scene::InternalSetEntityDepth(int depth_, BaseEntity *ent_) {
+        if (_EntityDepths.find(depth_) == _EntityDepths.end())
+            _EntityDepths.insert({ depth_, {} });
+        _EntityDepths[depth_].push_back(ent_);
+    }
+
+    void Scene::InternalUpdateEntityDepth(int oldDepth_, int newDepth_, BaseEntity *ent_) {
+        _EntityDepths[oldDepth_].erase(std::remove(_EntityDepths[oldDepth_].begin(), _EntityDepths[oldDepth_].end(), ent_), _EntityDepths[oldDepth_].end());
+
+        if (_EntityDepths.find(newDepth_) == _EntityDepths.end())
+            _EntityDepths.insert({ newDepth_, {} });
+        _EntityDepths[newDepth_].push_back(ent_);
     }
 
     void Scene::SetActiveCamera(Graphics::TCamera *camera_) {
@@ -57,5 +89,4 @@ namespace NerdThings::Ngine::Core {
         // Invoke updates
         OnUpdate({});
     }
-
 }

--- a/src/Core/Scene.h
+++ b/src/Core/Scene.h
@@ -33,6 +33,12 @@ namespace NerdThings::Ngine::Core {
          */
         Graphics::TCamera *_ActiveCamera = nullptr;
 
+        /*
+         * Depth key list containing entities.
+         * This is used for drawing.
+         */
+        std::map<int, std::vector<BaseEntity *>> _EntityDepths;
+
         // Private Methods
 
         void RemoveEntityParent(BaseEntity *ent_) override;
@@ -94,6 +100,16 @@ namespace NerdThings::Ngine::Core {
          * Get the currently active camera
          */
         [[nodiscard]] Graphics::TCamera *GetActiveCamera() const;
+
+        /*
+         * Set the entity depth in the scene (internally used)
+         */
+        void InternalSetEntityDepth(int depth_, BaseEntity *ent_);
+
+        /*
+         * Update the entity depth in the scene (internally used)
+         */
+        void InternalUpdateEntityDepth(int oldDepth_, int newDepth_, BaseEntity *ent_);
 
         /*
          * Set the currently active camera

--- a/src/Core/Scene.h
+++ b/src/Core/Scene.h
@@ -16,6 +16,7 @@
 
 #include "../ngine.h"
 
+#include "../Math/Rectangle.h"
 #include "../Graphics/Camera.h"
 #include "../EventArgs.h"
 #include "EntityContainer.h"
@@ -34,10 +35,41 @@ namespace NerdThings::Ngine::Core {
         Graphics::TCamera *_ActiveCamera = nullptr;
 
         /*
+         * Whether or not the cull area centers around
+         */
+        bool _CullAreaCenter = false;
+
+        /*
+         * The culling area height
+         */
+        float _CullAreaHeight;
+
+        /*
+         * The culling area width
+         */
+        float _CullAreaWidth;
+
+        /*
+         * Whether or not an entity is active
+         */
+        std::unordered_map<BaseEntity *, bool> _EntityActivities;
+
+        /*
          * Depth key list containing entities.
          * This is used for drawing.
          */
         std::map<int, std::vector<BaseEntity *>> _EntityDepths;
+
+        /*
+         * The parent game
+         */
+        Game* _ParentGame = nullptr;
+
+        /*
+         *
+         * The update counter
+         */
+        int _UpdateCounter = 0;
 
         // Private Methods
 
@@ -83,7 +115,7 @@ namespace NerdThings::Ngine::Core {
         /*
          * Create a new Scene
          */
-        Scene();
+        Scene(Game* parentGame_);
 
         // Public Destructor
 
@@ -102,6 +134,11 @@ namespace NerdThings::Ngine::Core {
         [[nodiscard]] Graphics::TCamera *GetActiveCamera() const;
 
         /*
+         * Get the culling area
+         */
+        Math::TRectangle GetCullArea() const;
+
+        /*
          * Set the entity depth in the scene (internally used)
          */
         void InternalSetEntityDepth(int depth_, BaseEntity *ent_);
@@ -115,6 +152,11 @@ namespace NerdThings::Ngine::Core {
          * Set the currently active camera
          */
         void SetActiveCamera(Graphics::TCamera *camera_);
+
+        /*
+         * Set the entity culling area
+         */
+        void SetCullArea(float width_, float height_, bool centerOnCamera_);
 
         /*
          * Update the scene

--- a/src/Math/Rectangle.cpp
+++ b/src/Math/Rectangle.cpp
@@ -26,6 +26,13 @@ namespace NerdThings::Ngine::Math {
 
     #endif
 
+    bool TRectangle::Contains(TVector2 point_) const {
+        return X <= point_.X
+            && point_.X < X + Width
+            && Y <= point_.Y
+            && point_.Y < Y + Height;
+    }
+
     Physics::TBoundingBox TRectangle::ToBoundingBox(const float rotation_, TVector2 origin_) const {
         // Fix origin
         origin_ += {X, Y};

--- a/src/Math/Rectangle.h
+++ b/src/Math/Rectangle.h
@@ -75,6 +75,11 @@ namespace NerdThings::Ngine::Math {
         #endif
 
         /*
+         * Whether or not the rectangle contains the point
+         */
+        bool Contains(TVector2 point_) const;
+
+        /*
          * Convert rectangle to bounding box
          */
         Physics::TBoundingBox ToBoundingBox(float rotation_ = 0, TVector2 origin_ = TVector2::Zero) const;

--- a/test/entrypoint.cpp
+++ b/test/entrypoint.cpp
@@ -90,8 +90,7 @@ public:
     TestEntity(Scene *parentScene_, const TVector2 &pos_) : BaseEntity(parentScene_, pos_) {
         AddComponent("HelloWorld", new HelloWorldComponent2D(this));
 
-        AddComponent("TestBoundingBox", new BoundingBoxCollisionShapeComponent(this, {0, 0, 100, 100}))->
-            EnableDebugDraw(true);
+        AddComponent("TestBoundingBox", new BoundingBoxCollisionShapeComponent(this, { 0, 0, 100, 100 }));
 
         TRectangle bounds = {0, 0, 100, 100};
         std::vector<TVector2> vertices = {{0, 0}, {100, 0}, {100, 100}, {0, 100}};
@@ -163,15 +162,15 @@ public:
 
         Drawing::DrawFPS({10, 100});
 
-        // for (auto i = 0; i < 800; i++) {
-        //     Drawing::DrawCircle({ 10.0f, 10.0f }, 5, TColor::Orange);
-        // }
+        for (auto i = 0; i < 800; i++) {
+            Drawing::DrawCircle({ 10.0f, 10.0f }, 5, TColor::Orange);
+        }
     }
 };
 
 class OtherEntity : public BaseEntity {
 public:
-    OtherEntity(Scene *parentScene_) : BaseEntity(parentScene_, TVector2::Zero) {
+    OtherEntity(Scene *parentScene_) : BaseEntity(parentScene_, TVector2::Zero, 0, true) {
         AddComponent("OtherComponent", new OtherComponent(this));
 
         AddComponent("TestBoundingBox", new BoundingBoxCollisionShapeComponent(this, {0, 0, 100, 100}))->
@@ -184,13 +183,19 @@ public:
 
         //AddComponent("TestPolygon", new PolygonCollisionShapeComponent(this, rect.ToPolygon()))->EnableDebugDraw(true);
     }
+
+    bool CheckForCulling(Math::TRectangle cullArea_) override {
+        auto a = cullArea_.ToPolygon();
+        auto b = TRectangle(GetPosition(), { 100, 100 }).ToPolygon();
+        return a.CheckCollision(&b);
+    }
 };
 
 class TestScene : public Scene {
 public:
     TCamera cam;
 
-    TestScene() : Scene() {
+    TestScene(Game* game) : Scene(game) {
         auto test = AddEntity("TestEntity", new TestEntity(this, {50, 100}));
         test->SetOrigin(TVector2(50, 50));
 
@@ -201,6 +206,10 @@ public:
         OnLoad.Bind(this, &TestScene::OnLoaded);
 
         OnDraw.Bind(this, &TestScene::Draw);
+
+        OnDrawCamera.Bind(this, &TestScene::DrawCam);
+
+        SetCullArea(1920 - 50, 1080 - 50, true);
     }
 
     void OnLoaded(SceneLoadEventArgs &e) {
@@ -214,7 +223,11 @@ public:
         //     Drawing::DrawCircle({ 10.0f, 10.0f }, 5, TColor::Orange);
         // }
 
-        //Drawing::DrawFPS({ 500, 300 });
+        Drawing::DrawFPS({ 500, 300 });
+    }
+
+    void DrawCam(EventArgs &e) {
+        Drawing::DrawRectangleLines(GetCullArea(), TColor::Green, 1);
     }
 };
 
@@ -235,7 +248,7 @@ public:
         Resources::LoadDirectory(exeDir + "\\content");
 
         // Create scene
-        _Scene = new TestScene();
+        _Scene = new TestScene(this);
 
         // Set scene
         SetScene(_Scene);

--- a/test/entrypoint.cpp
+++ b/test/entrypoint.cpp
@@ -162,6 +162,10 @@ public:
                           tcol);
 
         Drawing::DrawFPS({10, 100});
+
+        // for (auto i = 0; i < 800; i++) {
+        //     Drawing::DrawCircle({ 10.0f, 10.0f }, 5, TColor::Orange);
+        // }
     }
 };
 
@@ -200,13 +204,17 @@ public:
     }
 
     void OnLoaded(SceneLoadEventArgs &e) {
-        //AudioManager::Play(Resources::GetMusic("test_music"));
+        // AudioManager::Play(Resources::GetMusic("test_music"));
 
         AudioManager::SetMasterVolume(0.5);
     }
 
     void Draw(EventArgs &e) {
-        
+        // for (auto i = 0; i < 800; i++) {
+        //     Drawing::DrawCircle({ 10.0f, 10.0f }, 5, TColor::Orange);
+        // }
+
+        //Drawing::DrawFPS({ 500, 300 });
     }
 };
 
@@ -216,7 +224,7 @@ public:
 
     TestGame(int width_, int height_, int DrawFPS_, int UpdateFPS_, std::string title_) : Game(
         width_, height_, 1920, 1080, DrawFPS_, UpdateFPS_, title_,
-        MSAA_4X | MAINTAIN_DIMENSIONS | RESIZEABLE_WINDOW | VSYNC) {
+        MAINTAIN_DIMENSIONS | RESIZEABLE_WINDOW) {
         OnRun.Bind(this, &TestGame::Init);
     }
 


### PR DESCRIPTION
This is the alternative solution to issue #1, implementing a depth sorted vector that draws all entities in order (low depth tending to further back in the scene). This allows depth to be set and will be respected by the scene. I believe this is the candidate most likely to be merged as this has the highest performance.

### Merge Checklist
- [x] Review code
- [x] Create and report proper benchmarking (With and without vsync/msaa_4x)
- [x] Ready for merge